### PR TITLE
make Pushbar class importable by adding 'export default'

### DIFF
--- a/src/pushbar.js
+++ b/src/pushbar.js
@@ -1,4 +1,4 @@
-class Pushbar {
+export default class Pushbar {
     constructor(config = { overlay: true, blur: false }) {
         this.activeId;
         this.activeElement;


### PR DESCRIPTION
It would be nice if you could have publish a new version (on npmjs) with this modification.
(without it there is no way to import or require the module)